### PR TITLE
Rotated UR10 base 180° matching real robot

### DIFF
--- a/rbkairos_description/robots/rbkairos.urdf.xacro
+++ b/rbkairos_description/robots/rbkairos.urdf.xacro
@@ -176,7 +176,7 @@
 			</xacro:ur10_robot>
 			
 			<joint name="$(arg prefix)ur10_arm_base_joint" type="fixed">
-				<origin xyz="0.0 0 0.38212" rpy="0 0 ${PI*0}"/>
+				<origin xyz="0.0 0 0.38212" rpy="0 0 ${PI}"/>
 				<parent link="$(arg prefix)base_link" />
 				<child link="$(arg prefix)ur10_base_link" />
 			</joint>


### PR DESCRIPTION
Hello!

There seems to be a little inconsistency between our real world RB-Kairos with UR10 and the 3D model. The 3D arm is rotated 180° around the z axis differently than the real arm. Likewise, the electric plug of the real UR10 is on the left side of the robot, while on the 3D model it is at the right side.
Can you confirm and merge this? Are there other files which need to be changed too?

Thank you,
Reinhard