### PR TITLE
Added launch folder to the list of install directories

### DIFF
--- a/rbkairos_control/CMakeLists.txt
+++ b/rbkairos_control/CMakeLists.txt
@@ -12,6 +12,6 @@ catkin_package()
 include_directories(${catkin_INCLUDE_DIRS})
 
 install(
-  DIRECTORY config
+  DIRECTORY config launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/rbkairos_control/package.xml
+++ b/rbkairos_control/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>rbkairos_control</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>
 		This package contains the launch files that load the required controller interfaces for simulation in Gazebo.
   </description>


### PR DESCRIPTION
When the package is built into an installable package, the launch folder does not come with the package as it is not included in the CMakeLists.txt. I added this folder to the install directories.